### PR TITLE
Update webpack alias

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -93,7 +93,8 @@ const webpackConfig = {
     modules: ['./node_modules', './app'],
     extensions: ['.hbs', '.js', '.jsx', '.css', '.scss', '.json'],
     alias: {
-      Components: resolve(__dirname, './app/06.components')
+      Components: resolve(__dirname, './app/06.components'),
+      app: resolve(__dirname, './app')
     }
   },
   devServer: {


### PR DESCRIPTION
This in-app alias will help you access other things besides components without needing the relative annoying paths. E.g:
Let's say you're inside a component and need to access a service method. Currently you would need to do like this:

import myFetchFunction from '../../services/services'
Or create another alias to services in webpack

With the change you will be able to do so:
import myFetchFunction from 'app / services / services'

Depending on you may be able to survive quietly without the specific alias for the components as you had done before